### PR TITLE
Update `package.json` to allow flexible Node.js version for Vercel de…

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "preview": "pnpm run build && pnpm run start"
   },
   "engines": {
-    "node": "18.18.0"
+    "node": "18.x"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^0.0.39",


### PR DESCRIPTION
…ployment

- Modified the `engines` field in `package.json` to specify Node.js version as `18.x` instead of `18.18.0`.
- This change ensures compatibility with Vercel's requirements by allowing flexibility in minor and patch versions.